### PR TITLE
FIX: Include requirements.txt at the MANIFEST list.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include versioneer.py
 include timechart/_version.py
 include timechart_launcher/icons/*.png
+include requirements.txt
+


### PR DESCRIPTION
I bumped into this issue when I tried to install timechart at the ACR.
I was able to go forward with it by commenting out the read of the requirements file at `setup.py`.