### PR TITLE
MNT: strip spaces at beginning/end of PV names

### DIFF
--- a/timechart/displays/main_display.py
+++ b/timechart/displays/main_display.py
@@ -1126,6 +1126,7 @@ class TimeChartDisplay(Display):
         pv_name : str
             The name of the PV the curve is being plotted for
         """
+        pv_name = pv_name.strip()
         if pv_name and "://" not in pv_name:
             pv_name = ''.join([self.pv_protocol_cmb.currentText(), pv_name])
         return pv_name


### PR DESCRIPTION
## Issue

Closes #60 

## Resolution

Strip PV names before adding a new curve. Existing code ignores empty PV names.