### PR TITLE
FIX: do not force the open/save directories to '~' home

### DIFF
--- a/timechart/displays/chart_data_export_display.py
+++ b/timechart/displays/chart_data_export_display.py
@@ -178,49 +178,52 @@ class ChartDataExportDisplay(Display):
         self.file_format_cmb.setEnabled(False)
 
     def handle_save_file_btn_clicked(self):
-        saved_file_info = QFileDialog.getSaveFileName(
-            self, caption="Save File", directory=os.path.expanduser('~'),
-            filter=self.file_format)
-        saved_file_name = saved_file_info[0]
-        if saved_file_info[1][1:] not in saved_file_name:
-            saved_file_name += saved_file_info[1][1:]
+        saved_file_name, selected_filter = QFileDialog.getSaveFileName(
+            self,
+            caption="Save File",
+            filter=self.file_format
+        )
+        if not saved_file_name:
+            return
 
-        if saved_file_name:
-            if self.export_options_cmb.currentIndex() == 0:
-                data_exporter = CSVExporter(self.main_display.chart.plotItem)
-                data_exporter.export(saved_file_name)
-            elif self.export_options_cmb.currentIndex() == 2:
-                image_exporter = TimeChartImageExporter(
-                    self.main_display.chart.plotItem)
-                image_exporter.params = Parameter(name='params', type='group',
-                                                  children=[
-                                                      {'name': 'width',
-                                                       'type': 'int',
-                                                       'value': self.image_width,
-                                                       'limits': (0, None)},
-                                                      {'name': 'height',
-                                                       'type': 'int',
-                                                       'value': self.image_height,
-                                                       'limits': (0, None)},
-                                                      {'name': 'antialias',
-                                                       'type': 'bool',
-                                                       'value': True},
-                                                      {'name': 'background',
-                                                       'type': 'color',
-                                                       'value': self.exported_image_background_color},
-                                                  ])
+        if selected_filter[1:] not in saved_file_name:
+            saved_file_name += selected_filter[1:]
 
-                image_exporter.widthChanged()
-                image_exporter.heightChanged()
-                image_exporter.export(fileName=saved_file_name)
-            else:
-                settings_exporter = SettingsExporter(self.main_display,
-                                                     self.include_pv_chk.isChecked(),
-                                                     self.include_chart_settings_chk.isChecked())
-                settings_exporter.export_settings(saved_file_name)
+        if self.export_options_cmb.currentIndex() == 0:
+            data_exporter = CSVExporter(self.main_display.chart.plotItem)
+            data_exporter.export(saved_file_name)
+        elif self.export_options_cmb.currentIndex() == 2:
+            image_exporter = TimeChartImageExporter(
+                self.main_display.chart.plotItem)
+            image_exporter.params = Parameter(name='params', type='group',
+                                              children=[
+                                                  {'name': 'width',
+                                                   'type': 'int',
+                                                   'value': self.image_width,
+                                                   'limits': (0, None)},
+                                                  {'name': 'height',
+                                                   'type': 'int',
+                                                   'value': self.image_height,
+                                                   'limits': (0, None)},
+                                                  {'name': 'antialias',
+                                                   'type': 'bool',
+                                                   'value': True},
+                                                  {'name': 'background',
+                                                   'type': 'color',
+                                                   'value': self.exported_image_background_color},
+                                              ])
 
-            self.close()
-            QMessageBox.information(self, "Data Export", "Data exported successfully!")
+            image_exporter.widthChanged()
+            image_exporter.heightChanged()
+            image_exporter.export(fileName=saved_file_name)
+        else:
+            settings_exporter = SettingsExporter(self.main_display,
+                                                 self.include_pv_chk.isChecked(),
+                                                 self.include_chart_settings_chk.isChecked())
+            settings_exporter.export_settings(saved_file_name)
+
+        self.close()
+        QMessageBox.information(self, "Data Export", "Data exported successfully!")
 
     def handle_export_image_background_button_clicked(self):
         self.exported_image_background_color = QColorDialog.getColor()

--- a/timechart/displays/main_display.py
+++ b/timechart/displays/main_display.py
@@ -2,7 +2,6 @@
 The Main Display Window
 """
 
-import os
 import logging
 
 from functools import partial
@@ -33,7 +32,25 @@ from .axis_settings_display import AxisSettingsDisplay
 from .chart_data_export_display import ChartDataExportDisplay
 from ..utilities.utils import random_color, display_message_box
 
-from .defaults import *
+from .defaults import (
+    ASYNC_DATA_SAMPLING,
+    DEFAULT_CHART_AXIS_COLOR,
+    DEFAULT_CHART_BACKGROUND_COLOR,
+    DEFAULT_CHART_TITLE,
+    DEFAULT_DATA_SAMPLING_RATE_HZ,
+    # DEFAULT_EXPORTED_IMAGE_HEIGHT,
+    # DEFAULT_EXPORTED_IMAGE_WIDTH,
+    DEFAULT_REDRAW_RATE_HZ,
+    IMPORT_FILE_FORMAT,
+    MAX_DATA_SAMPLING_RATE_HZ,
+    MAX_DISPLAY_PV_NAME_LENGTH,
+    MAX_REDRAW_RATE_HZ,
+    MIN_DATA_SAMPLING_RATE_HZ,
+    MIN_REDRAW_RATE_HZ,
+    SYNC_DATA_SAMPLING,
+    X_AXIS_LABEL_SEPARATOR,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -999,18 +1016,23 @@ class TimeChartDisplay(Display):
         self.chart_data_export_disp.show()
 
     def handle_import_data_btn_clicked(self):
-        open_file_info = QFileDialog.getOpenFileName(self, caption="Open File", directory=os.path.expanduser('~'),
-                                                     filter=IMPORT_FILE_FORMAT)
-        open_filename = open_file_info[0]
-        if open_filename:
-            try:
-                importer = SettingsImporter(self)
-                importer.import_settings(open_filename)
-            except SettingsImporterException:
-                display_message_box(QMessageBox.Critical, "Import Failure",
-                                    "Cannot import the file '{0}'. Check the log for the error details."
-                                    .format(open_filename))
-                logger.exception("Cannot import the file '{0}'".format(open_filename))
+        open_filename, _ = QFileDialog.getOpenFileName(
+            self,
+            caption="Open File",
+            filter=IMPORT_FILE_FORMAT
+        )
+
+        if not open_filename:
+            return
+
+        try:
+            importer = SettingsImporter(self)
+            importer.import_settings(open_filename)
+        except SettingsImporterException:
+            display_message_box(QMessageBox.Critical, "Import Failure",
+                                "Cannot import the file '{0}'. Check the log for the error details."
+                                .format(open_filename))
+            logger.exception("Cannot import the file '{0}'".format(open_filename))
 
     def handle_sync_mode_radio_toggle(self, radio_btn):
         if radio_btn.isChecked():


### PR DESCRIPTION
## Issue

* Starting directory for open/save dialogs is forced to "$HOME"

Closes #68 
Closes #43 

## Resolution

* Qt does what we want it to in general by choosing the current working directory on the first invocation
* And on the second invocation, it remembers the past path where the user loaded/saved a file
* Added a couple cleanups/style fixes (removal of `import *`, reducing unecessary indentation)