### PR TITLE
ENH: Added ability to load PVs from command line

### DIFF
--- a/timechart/displays/main_display.py
+++ b/timechart/displays/main_display.py
@@ -3,7 +3,7 @@ The Main Display Window
 """
 
 import logging
-
+import argparse
 import os
 
 from functools import partial
@@ -430,6 +430,14 @@ class TimeChartDisplay(Display):
         self.time_span_limit_seconds = None
         self.data_sampling_mode = ASYNC_DATA_SAMPLING
 
+        parser = argparse.ArgumentParser(description='TimeChart')
+        parser.add_argument("--pvs", help="Launch TimeChart with PVs loaded from command line", nargs='*')
+        args = parser.parse_args()
+        self.pv_arg_list = args.pvs
+        if len(self.pv_arg_list):
+            self.add_curve_command_line()
+
+
         # If there is an imported config file, let's start TimeChart with the imported configuration data
         if config_file:
             importer = SettingsImporter(self)
@@ -710,6 +718,21 @@ class TimeChartDisplay(Display):
             self.add_y_channel(pv_name=pv_name, curve_name=pv_name, color=color)
             self.handle_splitter_button(left=True)
 
+    def add_curve_command_line(self):
+        """
+        Add curves to the chart from the command line.
+        """
+        for pv in self.pv_arg_list:
+            pv_name = self._get_full_pv_name(pv)
+            if pv_name and len(pv_name):
+                color = random_color(curve_colors_only=True)
+                for k, v in self.channel_map.items():
+                    if color == v.color:
+                        color = random_color(curve_colors_only=True)
+
+                self.add_y_channel(pv_name=pv_name, curve_name=pv_name, color=color)
+                self.handle_splitter_button(left=True)
+                
     def show_mouse_coordinates(self, x, y):
         self.crosshair_coord_lbl.clear()
         self.crosshair_coord_lbl.setText(
@@ -1049,7 +1072,7 @@ class TimeChartDisplay(Display):
         try:
             importer = SettingsImporter(self)
             importer.import_settings(open_filename)
-            
+
             terse_name = os.path.split(open_filename)[1]
             self.setWindowTitle("TimeChart Tool - " + terse_name)
         except SettingsImporterException:
@@ -1236,3 +1259,4 @@ class TimeChartDisplay(Display):
     @property
     def gridAlpha(self):
         return self.grid_alpha
+

--- a/timechart/displays/main_display.py
+++ b/timechart/displays/main_display.py
@@ -3,7 +3,7 @@ The Main Display Window
 """
 
 import logging
-import argparse
+
 import os
 
 from functools import partial
@@ -74,6 +74,7 @@ class TimeChartDisplay(Display):
         """
         super(TimeChartDisplay, self).__init__(parent=parent, args=args,
                                                macros=macros)
+
         self.legend_font = None
         self.channel_map = dict()
         self.setWindowTitle("TimeChart Tool")
@@ -430,14 +431,6 @@ class TimeChartDisplay(Display):
         self.time_span_limit_seconds = None
         self.data_sampling_mode = ASYNC_DATA_SAMPLING
 
-        parser = argparse.ArgumentParser(description='TimeChart')
-        parser.add_argument("--pvs", help="Launch TimeChart with PVs loaded from command line", nargs='*')
-        args = parser.parse_args()
-        self.pv_arg_list = args.pvs
-        if len(self.pv_arg_list):
-            self.add_curve_command_line()
-
-
         # If there is an imported config file, let's start TimeChart with the imported configuration data
         if config_file:
             importer = SettingsImporter(self)
@@ -704,11 +697,15 @@ class TimeChartDisplay(Display):
             self.chart_control_frame.show()
             self.pv_add_panel.show()
 
-    def add_curve(self):
+    def add_curve(self, command_pv=None):
         """
         Add a new curve to the chart.
         """
-        pv_name = self._get_full_pv_name(self.pv_name_line_edt.text())
+        if command_pv:
+            pv_name = self._get_full_pv_name(command_pv)
+        else:
+            pv_name = self._get_full_pv_name(self.pv_name_line_edt.text())
+
         if pv_name and len(pv_name):
             color = random_color(curve_colors_only=True)
             for k, v in self.channel_map.items():
@@ -718,21 +715,6 @@ class TimeChartDisplay(Display):
             self.add_y_channel(pv_name=pv_name, curve_name=pv_name, color=color)
             self.handle_splitter_button(left=True)
 
-    def add_curve_command_line(self):
-        """
-        Add curves to the chart from the command line.
-        """
-        for pv in self.pv_arg_list:
-            pv_name = self._get_full_pv_name(pv)
-            if pv_name and len(pv_name):
-                color = random_color(curve_colors_only=True)
-                for k, v in self.channel_map.items():
-                    if color == v.color:
-                        color = random_color(curve_colors_only=True)
-
-                self.add_y_channel(pv_name=pv_name, curve_name=pv_name, color=color)
-                self.handle_splitter_button(left=True)
-                
     def show_mouse_coordinates(self, x, y):
         self.crosshair_coord_lbl.clear()
         self.crosshair_coord_lbl.setText(

--- a/timechart_launcher/main.py
+++ b/timechart_launcher/main.py
@@ -64,7 +64,10 @@ def main():
     if args.config_file:
         config_file = os.path.expandvars(os.path.expanduser(args.config_file))
 
-    display = TimeChartDisplay(config_file=config_file, args=extra_args)
+    display = TimeChartDisplay(config_file=config_file)
+    if args.pvs:    
+        for pv in args.pvs:    
+            display.add_curve(pv)
     display.show()
 
     sys.exit(app.exec_())
@@ -95,6 +98,8 @@ def _parse_arguments():
                         version='TimeChart {version}'.format(
                             version=timechart.__version__))
 
+    parser.add_argument("--pvs", help="Launch TimeChart with PVs loaded from the command line.", nargs='*')
+
     args, extra_args = parser.parse_known_args()
     return args, extra_args
 
@@ -104,3 +109,4 @@ if __name__ == "__main__":
         main()
     except Exception as error:
         traceback.print_exc()
+


### PR DESCRIPTION
Added feature that allows user to load a list of PVs from the command line.  Use the argument --pvs "pv1" "pv2" "pv3" to create the list of PVs to be loaded.  Ex. `python -m timechart_launcher.main -p "SIOC:SYS0:MG06:HEARTBEAT"`.  See #63 