### PR TITLE
ENH: Application Startup Script & CRAM integration 

### DIFF
--- a/timechart.bash
+++ b/timechart.bash
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+source $TOOLS/script/use_python3_devel.sh
+
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+python -m timechart_launcher.main $@


### PR DESCRIPTION
(Closes #72)

Created a startup script: timechart.bash
This file sources the correct environment ($TOOLS/script/use_python3_devel.sh) which can be changed as needed.

I also added the most recent version of TimeChart to CRAM on Dev. This means that you can run the script (in it's current condition) from anywhere on lcls-dev3.

I was unable to find a way to link the local git repo used by eco/cram to the existing slaclab/timechart repo, so updating the CRAM version will take extra work.