### PR TITLE
Fixing startup script

### DIFF
--- a/timechart.bash
+++ b/timechart.bash
@@ -2,6 +2,6 @@
 
 source $TOOLS/script/use_python3_devel.sh
 
-cd "$(dirname "${BASH_SOURCE[0]}")"
+cd "$(dirname "$(readlink -f ${BASH_SOURCE[0]})")"
 
 python -m timechart_launcher.main $@


### PR DESCRIPTION
Fixing startup script to account for symlinks. This is done using the `readlink -f` command.